### PR TITLE
タイトル画面が出ないようにした

### DIFF
--- a/game/script.rpy
+++ b/game/script.rpy
@@ -7,6 +7,9 @@
 """
 define g = Character('girl', color="#c8ffc8")
 
+label main_menu:
+    return
+
 label start:
 
     jump d01


### PR DESCRIPTION
```renpy
label main_menu:
    return
```
と書くとタイトルが表示されないみたいです。