### PR TITLE
クリックイベントを詳しく、鍵の出現条件変更

### DIFF
--- a/game/scripts/pr/events/book_clicked.rpy
+++ b/game/scripts/pr/events/book_clicked.rpy
@@ -3,6 +3,8 @@
 """
 
 label pr_book_clicked:
+    if check_main():
+        $ event_end()
     show girl at right with dissolve
 
     if jumped_pr_door_clicked:

--- a/game/scripts/pr/events/book_clicked.rpy
+++ b/game/scripts/pr/events/book_clicked.rpy
@@ -3,28 +3,34 @@
 """
 
 label pr_book_clicked:
-
     show girl at right with dissolve
-    g "この本、違和感があるね"
+
+    if jumped_pr_door_clicked:
     
-    $ delete_obj("Book")
-    $ make_obj("Book Opened")
-    $ make_obj('Key') # 鍵オブジェクトを生成
+        g "この本、違和感があるね"
+        
+        $ delete_obj("Book")
+        $ make_obj("Book Opened")
+        $ make_obj('Key') # 鍵オブジェクトを生成
 
-    show girl surprise at right with dissolve
+        show girl surprise at right with dissolve
 
-    show screen pr_screen(read_room()) # 鍵を表示させるためにスクリーン更新する
+        show screen pr_screen(read_room()) # 鍵を表示させるためにスクリーン更新する
 
-    g "わ、中に鍵がはいってた"
+        g "わ、中に鍵がはいってた"
 
-    show girl at right with dissolve
+        show girl at right with dissolve
 
-    g "この鍵、使えそうだね"
+        g "この鍵、使えそうだね"
+
+
+    else:
+
+        g "本が落ちてるね"
 
     hide girl with dissolve
 
-    $ event_end(loop_label())
-
+    $ event_end()
 
 label pr_book_opened_clicked:
 

--- a/game/scripts/pr/events/clock_clicked.rpy
+++ b/game/scripts/pr/events/clock_clicked.rpy
@@ -1,5 +1,6 @@
 label pr_clock_clicked:
-
+    if check_main():
+        $ event_end()
     show girl at right with dissolve
     
     g "時計があるね"

--- a/game/scripts/pr/events/door_opened.rpy
+++ b/game/scripts/pr/events/door_opened.rpy
@@ -1,4 +1,5 @@
 label pr_door_opened:
+
     show girl at right with dissolve
 
     $ delete_obj("Door")

--- a/game/scripts/pr/events/door_opened_clicked.rpy
+++ b/game/scripts/pr/events/door_opened_clicked.rpy
@@ -3,6 +3,8 @@
 """
 
 label pr_door_opened_clicked:
+    if check_main():
+        $ event_end()
     # 初めてこのラベルにジャンプしたとき
     if not jumped_pr_door_opened_clicked:
 

--- a/game/scripts/pr/events/door_opened_clicked.rpy
+++ b/game/scripts/pr/events/door_opened_clicked.rpy
@@ -42,9 +42,23 @@ label pr_door_opened_clicked:
 
         show girl at right with dissolve
 
-        g "別のプログラムを起動すれば、このドアが通れるようになるはずだよ"
+        g "このドアの先は、別のプログラムにつながってると思う"
 
-        g "探してきて"
+        g "それを起動すれば、この先へ行けるはずだよ"
+
+        g "ちなみに、いま私たちがいるこの場所は......"
+
+        $ path = os.path.join(config.basedir, current_room)
+
+        g "\"[path]\"だよ"
+
+        g "君がこのゲームを最初に起動したときに実行したファイルも、この近くにあるよね"
+
+        g "これとは別にもう一つ実行ファイルがあるはず"
+
+        show girl smile at right with dissolve
+
+        g "それを探してきて"
 
     hide girl
     with dissolve

--- a/game/scripts/pr/events/other_clicked.rpy
+++ b/game/scripts/pr/events/other_clicked.rpy
@@ -1,4 +1,6 @@
 label pr_key_clicked:
+    if check_main():
+        $ event_end()
     show girl at right with dissolve
 
     g "古い鍵だね"
@@ -12,7 +14,8 @@ label pr_key_clicked:
     $ event_end(loop_label())
 
 label pr_door_clicked:
-
+    if check_main():
+        $ event_end()
     $ jumped_pr_door_clicked = True
 
     show girl at right with dissolve

--- a/game/scripts/pr/events/other_clicked.rpy
+++ b/game/scripts/pr/events/other_clicked.rpy
@@ -1,11 +1,30 @@
 label pr_key_clicked:
+    show girl at right with dissolve
 
-    call say_simple("古い鍵だね")
+    g "古い鍵だね"
+
+    show girl look away at right with dissolve
+
+    g "浮いているように見えるかもしれないけど、それはご愛敬ということで......よろしく......"
+
+    show girl at right with dissolve
 
     $ event_end(loop_label())
 
 label pr_door_clicked:
 
-    call say_simple("鍵がかかってるみたい")
+    $ jumped_pr_door_clicked = True
+
+    show girl at right with dissolve
+
+    g "鍵がかかってるみたい"
+
+    g "どこかに鍵はないかな"
+
+    show girl smile at right with dissolve
+
+    g "探してきてもらえる？"
+    
+    hide girl with dissolve
 
     $ event_end(loop_label())

--- a/game/scripts/pr/start.rpy
+++ b/game/scripts/pr/start.rpy
@@ -10,6 +10,8 @@ default pr_main_activated = False  # Mainのプログラムが起動されたと
 
 default key_dropped = False # KeyがドロップされるとTrue
 
+default jumped_pr_door_clicked = False  # 閉じたドアが一回以上クリックされたかどうか
+
 label pr_start:
     if pr_evflg_opening:
         $ init_room("simple room")

--- a/game/scripts/pr/start.rpy
+++ b/game/scripts/pr/start.rpy
@@ -42,7 +42,7 @@ label .scloop:
         pass  # 何か書くかも？
 
     # KeyがDoorにドロップされたときのイベント
-    if key_dropped:
+    if key_dropped and not check_main():
         python:
             key_dropped = False
             if not pr_door_opened:


### PR DESCRIPTION
# 実装した内容

ドアをクリックしてから出ないと、鍵が生成されないようにしました
各種クリックイベントで、ヒントを潤沢にしました

また、mainの起動後はイベントを起こさないようにしました